### PR TITLE
Update the Readme to include the Apache License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 <!-- markdownlint-enable -->
 
-
 `beman.copyable_function` is a type-erased function wrapper that can represent any copyable callable matching
 the function signature R(Args...). The library conforms to the [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md).
 
@@ -21,7 +20,6 @@ the function signature R(Args...). The library conforms to the [The Beman Standa
 beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
 
 ## Usage
-
 
 The following code snippet illustrates `copyable_function`:
 
@@ -45,7 +43,6 @@ int main()
 
 ```
 
-
 ## Dependencies
 
 ### Build Environment
@@ -61,7 +58,6 @@ thus requiring an active internet connection to configure.
 You can disable this behavior by setting cmake option
 [`BEMAN_EXEMPLAR_BUILD_TESTS`](#beman_exemplar_build_tests) to `OFF`
 when configuring the project.
-
 
 ### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ the function signature R(Args...). The library conforms to the [The Beman Standa
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 
+## License
+
+beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
+
 ## Usage
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the function signature R(Args...). The library conforms to the [The Beman Standa
 
 ## License
 
-beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
+beman.copyable\_function is licensed under the Apache License v2.0 with LLVM Exceptions.
 
 ## Usage
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/253

Before:
```bash
[error][readme.license]: The file 'README.md' does not contain a `## License` section. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmelicense.
	check [Requirement][readme.license] ... failed
```

After:
```
Running check [Requirement][readme.license] ... 
	check [Requirement][readme.license] ... passed
```

