### PR TITLE
Update the badges with the corect one

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 <!-- markdownlint-disable -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)
 ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
-![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 <!-- markdownlint-enable -->
 
 `beman.copyable_function` is a type-erased function wrapper that can represent any copyable callable matching


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/253

- Update the old badge with the correct one:
![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg) ->
![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)

beman-tidy before:

```bash

[error][readme.badges]: The file 'README.md' does not contain exactly one required badge of category 'standard_target'.
	check [Requirement][readme.badges] ... failed
```

beman-tidy after:

```bash
Running check [Requirement][readme.badges] ... 
	check [Requirement][readme.badges] ... passed

```