### PR TITLE
Disable failing markdownlint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,11 @@ repos:
       name: CMake linting
 
     # Markdown linting
-    # Config file: .markdownlint.yaml
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
-    hooks:
-    - id: markdownlint
+    # Commented out to disable this by default. Uncomment to enable markdown linting.
+  # - repo: https://github.com/igorshubovych/markdownlint-cli
+  #   rev: v0.42.0
+  #   hooks:
+  #   - id: markdownlint
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0


### PR DESCRIPTION
This check is disabled in exemplar and causes this repo's pre-commit check to fail. The maintainer can uncomment it and fix the check later on if desired.
