### PR TITLE
Fix unused variable x in sample_usage.cpp

### DIFF
--- a/examples/sample_usage.cpp
+++ b/examples/sample_usage.cpp
@@ -10,6 +10,5 @@ struct Callable {
 
 int main() {
     beman::copyable_function<int()> f(Callable{});
-    int                             x = f();
-    return 0;
+    return f();
 }


### PR DESCRIPTION
## Summary

- Replace `int x = f(); return 0;` with `return f();` in `examples/sample_usage.cpp`
- Fixes `-Werror=unused-variable` compiler error introduced in fe10bee

Fixes the issue reported by @eddienolan.

## Test plan

- [x] Confirm `-Werror` CI job passes after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue: https://github.com/bemanproject/copyable_function/pull/15