### PR TITLE
Fix clang-format

### DIFF
--- a/include/beman/copyable_function/copyable_function_impl.hpp
+++ b/include/beman/copyable_function/copyable_function_impl.hpp
@@ -7,20 +7,20 @@
 #include "copyable_function_helper.h"
 
 #ifndef _CONST
-#define _CONST
+    #define _CONST
 #endif
 
 #ifndef _REF
-#define _REF
-#define INVOKE_QUALS _CONST&
+    #define _REF
+    #define INVOKE_QUALS _CONST&
 
 #else
-#define INVOKE_QUALS _CONST _REF
+    #define INVOKE_QUALS _CONST _REF
 
 #endif
 
 #ifndef _COPYABLE_FUNC_NOEXCEPT
-#define _COPYABLE_FUNC_NOEXCEPT false
+    #define _COPYABLE_FUNC_NOEXCEPT false
 #endif
 
 namespace beman {

--- a/tests/beman/copyable_function/call.test.cpp
+++ b/tests/beman/copyable_function/call.test.cpp
@@ -60,13 +60,13 @@ TEST(CallTest, CallTestUsingRvalueReference) {
 
 TEST(CallTest, CallTestWithLvalueRef) {
     {
-        beman::copyable_function<int()&> f(Callable{});
-        int                              x = f();
+        beman::copyable_function<int() &> f(Callable{});
+        int                               x = f();
         EXPECT_EQ(x, 42);
     }
     {
-        beman::copyable_function<int()&> f(LargeCallable{});
-        int                              x = f();
+        beman::copyable_function<int() &> f(LargeCallable{});
+        int                               x = f();
         EXPECT_EQ(x, 1);
     }
 }


### PR DESCRIPTION
b256d88759ff581c0ead43779d36dd47eadf871 uepdated the clang-format version and configuration but did not re-run clang-format, breaking the CI check on master. This commit addresses the issue by checking in the results of a clang-format run.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
