### PR TITLE
fix: add missing SPDX-License-Identifier headers (file.license_id)

### DIFF
--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:

--- a/include/beman/copyable_function/copyable_function_helper.h
+++ b/include/beman/copyable_function/copyable_function_helper.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef BEMAN_COPYABLE_FUNCTION_HELPER
 #define BEMAN_COPYABLE_FUNCTION_HELPER
 

--- a/include/beman/copyable_function/copyable_function_impl.hpp
+++ b/include/beman/copyable_function/copyable_function_impl.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <utility>
 #include <functional>
 #include <type_traits>

--- a/infra/.github/workflows/pre-commit.yml
+++ b/infra/.github/workflows/pre-commit.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 name: Lint Check (pre-commit)
 
 on:

--- a/infra/.pre-commit-config.yaml
+++ b/infra/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/infra/cmake/BuildTelemetry.cmake
+++ b/infra/cmake/BuildTelemetry.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)

--- a/infra/cmake/BuildTelemetryConfig.cmake
+++ b/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 include_guard(GLOBAL)
 
 set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/infra/cmake/telemetry.sh
+++ b/infra/cmake/telemetry.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set -o nounset
 set -o errexit

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)

--- a/tests/beman/copyable_function/common.h
+++ b/tests/beman/copyable_function/common.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef COMMON_H
 #define COMMON_H
 


### PR DESCRIPTION
## Summary

Fixes the `file.license_id` beman-tidy **Requirement** check by adding `SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception` to 12 files that were missing it.

Note: Latest https://github.com/bemanproject/infra/tree/main will apply these changes anyways!

## Test plan

- [x] `beman-tidy --checks "file.license_id" .` passes after this change
